### PR TITLE
Hacky update

### DIFF
--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -19,9 +19,10 @@ var fromLanguage = userINFO.fromLanguage;
 //var languagestring = duo.user.get("learning_language");
 //var loc = window.location.pathname;
 */
-var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learningLanguage || JSON.parse(GM.getValue('duo.state')).user.learningLanguage || window.location.pathname.split("/").slice( 2, 3 ).join("/");
 
 //GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
+function changebackground(){
+    var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learningLanguage || JSON.parse(GM.getValue('duo.state')).user.learningLanguage || window.location.pathname.split("/").slice( 2, 3 ).join("/");
 	var backgroundurl = "notset";
     switch(languagestring){
         case "da":
@@ -126,9 +127,23 @@ var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learning
 			backgroundurl = "http://i.imgur.com/3KI66sY.jpg";
             break;
     }
-  GM_addStyle(".gr__duolingo_com, body, body:first-child, ._3MLiB, ._3giip, ._3PBCS{background:url("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
+    GM_addStyle(".gr__duolingo_com, body, body:first-child, ._3MLiB, ._3giip, ._3PBCS{background:url("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 //GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 //
+//footer
+//GM_addStyle("._3GXmV, ._1sntG{background:none");
+GM_addStyle("._3GXmV{background:none"); //_3uFh7 _3BtZs _1sntG
+  //nvm on this one, short flags don't fill to bottom
+//home page underfooter with wide window: <div data-reactroot="">
+GM_addStyle("body div div("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}");
+}
+changebackground();
+//change background on language select?
+//$('_3gtu3 _1-Eux iDKFi').click(function(){alert("hi")});
+window.setInterval(function(){
+  changebackground();
+}, 60000);
+
 GM_addStyle(".nav-footer{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
 //GM_addStyle(".nav-footer a{color:white");
     //$("#app").css("background", "url('http://i.imgur.com/W6psVNL.png') no-repeat bottom center fixed");
@@ -138,15 +153,10 @@ GM_addStyle("._1Zqmf{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #F
 GM_addStyle("._38VWB{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
 //beginner card
 GM_addStyle(".a-Y8L{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
-//footer
-//GM_addStyle("._3GXmV, ._1sntG{background:none");
-GM_addStyle("._3GXmV{background:none"); //_3uFh7 _3BtZs _1sntG
+
 //mark all correct answers
 GM_addStyle(".maOx8, ._2hYEZ{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
 
-//nvm on this one, short flags don't fill to bottom
-//home page underfooter with wide window: <div data-reactroot="">
-GM_addStyle("body div div("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 //multiple select the word question text
 GM_addStyle(".oR3Zt{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
 //lesson complete ._26pCf / XP earned ._3jPAB / combo bonus _26pCf / XP _3jPAB

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -117,21 +117,25 @@ var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learning
   GM_addStyle(".gr__duolingo_com, body, body:first-child, ._3MLiB, ._3giip, ._3PBCS{background:url("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 //GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 //
-GM_addStyle(".nav-footer{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
-GM_addStyle(".nav-footer a{color:white");
+GM_addStyle(".nav-footer{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
+//GM_addStyle(".nav-footer a{color:white");
     //$("#app").css("background", "url('http://i.imgur.com/W6psVNL.png') no-repeat bottom center fixed");
     //
 //write this in english
-GM_addStyle("._1Zqmf{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
-GM_addStyle("._38VWB{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
+GM_addStyle("._1Zqmf{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
+GM_addStyle("._38VWB{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
 //beginner card
-GM_addStyle(".a-Y8L{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
+GM_addStyle(".a-Y8L{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
 //footer
 //GM_addStyle("._3GXmV, ._1sntG{background:none");
 GM_addStyle("._3GXmV{background:none"); //_3uFh7 _3BtZs _1sntG
 //mark all correct answers
-GM_addStyle(".maOx8, ._2hYEZ{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
+GM_addStyle(".maOx8, ._2hYEZ{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
 
 //nvm on this one, short flags don't fill to bottom
 //home page underfooter with wide window: <div data-reactroot="">
 GM_addStyle("body div div("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
+//multiple select the word question text
+GM_addStyle(".oR3Zt{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");
+//lesson complete ._26pCf / XP earned ._3jPAB / combo bonus _26pCf / XP _3jPAB
+GM_addStyle("._1iUq9{text-shadow:1px 1px 0 #FFF, -1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF");

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -114,6 +114,10 @@ var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learning
             // Korean flag
             backgroundurl = "https://pre00.deviantart.net/d168/th/pre/i/2009/041/d/b/south_korea_grunge_flag_by_think0.jpg";
 			break;
+        case "ja":
+            // Japanese flag
+            backgroundurl = "https://img01.deviantart.net/b3f0/i/2010/331/c/4/japan_grunge_flag_by_think0-d1urafh.jpg";
+			break;
         case "en":
             // American flag
             backgroundurl = "http://i.imgur.com/3KI66sY.jpg";

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -106,6 +106,10 @@ var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learning
             // Saudia Arabia
             backgroundurl = "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/2bf3899e-48a5-412e-95c6-fe219464eb57/d1tnilc-70340cf2-af27-45e3-a511-65230d6b770c.jpg/v1/fill/w_1095,h_730,q_70,strp/saudi_arabia_grungy_flag_by_think0_d1tnilc-pre.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7ImhlaWdodCI6Ijw9MTA2NyIsInBhdGgiOiJcL2ZcLzJiZjM4OTllLTQ4YTUtNDEyZS05NWM2LWZlMjE5NDY0ZWI1N1wvZDF0bmlsYy03MDM0MGNmMi1hZjI3LTQ1ZTMtYTUxMS02NTIzMGQ2Yjc3MGMuanBnIiwid2lkdGgiOiI8PTE2MDAifV1dLCJhdWQiOlsidXJuOnNlcnZpY2U6aW1hZ2Uub3BlcmF0aW9ucyJdfQ.aDPFeNNYJPbwnKWN2eBhU2iw9T4nia0r5q7L4NZviBA";
 			break;
+        case "zh":
+            // Chinese flag
+            backgroundurl = "https://img13.deviantart.net/0a53/i/2009/026/e/2/people__s_republic_of_china_gf_by_think0.jpg";
+			break;
         case "en":
             // American flag
             backgroundurl = "http://i.imgur.com/3KI66sY.jpg";

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -100,6 +100,12 @@ var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learning
             // Icelandic flag
             backgroundurl = "http://i.imgur.com/o8kcT4L.jpg";
 			break;
+        case "ar":
+            // Palestinian flag
+            backgroundurl = "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/2bf3899e-48a5-412e-95c6-fe219464eb57/d1tf8um-7b09252c-3e17-4fb5-b1ce-42df4746bd34.jpg/v1/fill/w_900,h_598,q_75,strp/palestine_grungy_flag_by_think0_d1tf8um-fullview.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7ImhlaWdodCI6Ijw9NTk4IiwicGF0aCI6IlwvZlwvMmJmMzg5OWUtNDhhNS00MTJlLTk1YzYtZmUyMTk0NjRlYjU3XC9kMXRmOHVtLTdiMDkyNTJjLTNlMTctNGZiNS1iMWNlLTQyZGY0NzQ2YmQzNC5qcGciLCJ3aWR0aCI6Ijw9OTAwIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmltYWdlLm9wZXJhdGlvbnMiXX0.aKffWoBBoA82u3XGhq1CRo8-s2He0DRiXyxiJnskFNY";
+            // Saudia Arabia
+            backgroundurl = "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/2bf3899e-48a5-412e-95c6-fe219464eb57/d1tnilc-70340cf2-af27-45e3-a511-65230d6b770c.jpg/v1/fill/w_1095,h_730,q_70,strp/saudi_arabia_grungy_flag_by_think0_d1tnilc-pre.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7ImhlaWdodCI6Ijw9MTA2NyIsInBhdGgiOiJcL2ZcLzJiZjM4OTllLTQ4YTUtNDEyZS05NWM2LWZlMjE5NDY0ZWI1N1wvZDF0bmlsYy03MDM0MGNmMi1hZjI3LTQ1ZTMtYTUxMS02NTIzMGQ2Yjc3MGMuanBnIiwid2lkdGgiOiI8PTE2MDAifV1dLCJhdWQiOlsidXJuOnNlcnZpY2U6aW1hZ2Uub3BlcmF0aW9ucyJdfQ.aDPFeNNYJPbwnKWN2eBhU2iw9T4nia0r5q7L4NZviBA";
+			break;
         case "en":
             // American flag
             backgroundurl = "http://i.imgur.com/3KI66sY.jpg";

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -12,12 +12,15 @@
 
 //HACKY HACK USE AS REFERENCE TO FIX ORIGINAL
 
+/*
 var uiLanguage = duo.uiLanguage;
 var fromLanguage = userINFO.fromLanguage;
 //var toLanguage = userINFO.toLanguage; y u no exist‽
 //var languagestring = duo.user.get("learning_language");
 //var loc = window.location.pathname;
 var languagestring = window.location.pathname.split("/").slice( 2, 3 ).join("/");
+*/
+var languagestring = JSON.parse(localStorage.getItem("duo.state")).user.learningLanguage;
 
 //GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 	var backgroundurl = "notset";

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -1,180 +1,104 @@
 // ==UserScript==
-// @name         Duolingo Flag background
-// @namespace   a34c0ac7aca179b6312214a6e1697b5a
-// @description  Adds more duo to the website, so that it doesn't seem as boring when you're trying to maintain your streak!
-// @author       Victor Williams
+// @name New Script
+// @namespace Violentmonkey Scripts
 // @match        *://www.duolingo.com/*
-// @grant        none
-// @copyright    2016, Victor Williams
-// @updateURL   https://monkeyguts.com/828.meta.js?c
-// @downloadURL https://monkeyguts.com/828.user.js?c
-//FEEL FREE TO ADD TO THIS IF YOU WANT 
-//DUOLINGO NEEDS TO BE FUN
+// @match        https://www.duolingo.com/*
+// @match        http://www.duolingo.com/*
+// @match        https://www.duolingo.cn/*
+// @match        http://www.duolingo.cn/*
+// @grant        GM_addStyle
 // ==/UserScript==
-function doFlag(){
-    var languagestring = duo.user.get("learning_language");
-  var backgroundurl = "notset";
+// 
+
+//HACKY HACK USE AS REFERENCE TO FIX ORIGINAL
+;var loc = window.location.pathname;
+var languagestring = window.location.pathname.split("/").slice( 2, 3 ).join("/");
+//GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
+	var backgroundurl = "notset";
     switch(languagestring){
         case "da":
             // Danish flag
             backgroundurl = "http://i.imgur.com/MVKImbX.jpg";
-      break;
+			break;
         case "sv":
             // Swedish flag
             backgroundurl = "http://i.imgur.com/VN547Ku.jpg";
-      break;
+			break;
         case "nb":
             // Norwegian flag
             backgroundurl = "http://i.imgur.com/GZSVizM.jpg";
-      break;
+			break;
         case "eo":
             // Esperanto flag
             backgroundurl = "http://i.imgur.com/RqTOULB.jpg";
-      break;
+			break;
         case "vi":
             // Vietnam flag
             backgroundurl = "http://i.imgur.com/8fF8Qz3.jpg";
-      break;
+			break;
         case "hu":
             // Hungarian flag
             backgroundurl = "http://i.imgur.com/AHl1KqM.jpg";
-      break;
+			break;
         case "tr":
             // Turkish flag
             backgroundurl = "http://i.imgur.com/diItxKa.jpg";
-      break;
+			break;
         case "ga":
             // Irish flag
             backgroundurl = "http://i.imgur.com/Dbi7nPR.jpg";
-      break;
+			break;
         case "fr":
             // French flag
             backgroundurl = "http://i.imgur.com/AUxfmNS.jpg";
-      break;
+			break;
         case "it":
             // Italian flag
             backgroundurl = "http://i.imgur.com/qOjj10n.jpg";
-      break;
+			break;
         case "de":
             // German flag
             backgroundurl = "http://i.imgur.com/KjM0RNL.jpg";
-      break;
+			break;
         case "dn":
             // Dutch flag
             backgroundurl = "http://i.imgur.com/ibQ5R2y.jpg";
-      break;
+			break;
         case "es":
             // Spanish flag
             backgroundurl = "http://i.imgur.com/Xdensoa.jpg";
-      break;
+			break;
         case "pt":
             // Brazil flag
             backgroundurl = "http://i.imgur.com/vGHMaiK.jpg";
-      break;
+			break;
         case "uk":
             // Ukraine flag
             backgroundurl = "http://i.imgur.com/NZQtpAa.jpg";
-      break;
+			break;
         case "pl":
             // Polish flag
             backgroundurl = "http://i.imgur.com/gJ0aMso.jpg";
-      break;
+			break;
         case "ru":
             // Russian flag
             backgroundurl = "hhttp://i.imgur.com/shKQqnR.jpg";
-      break;
+			break;
         case "el":
             // Greek flag
             backgroundurl = "http://i.imgur.com/QdWgibY.jpg";
-      break;
+			break;
         case "is":
             // Icelandic flag
             backgroundurl = "http://i.imgur.com/o8kcT4L.jpg";
-      break;
+			break;
         case "en":
-            // British Flag
-            backgroundurl = "http://i.imgur.com/PhbibAE.jpg";
-      break;
-        case "ca":
-            //Catalan Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Flag_of_Catalonia.svg/2000px-Flag_of_Catalonia.svg.png";
-      break;
-        
-            //Egyptian Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Flag_of_Egypt.svg/2000px-Flag_of_Egypt.svg.png";
-      break;
-        case "ro"
-            //Romanian Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/Flag_of_Romania.svg/2000px-Flag_of_Romania.svg.png";
-      break;
-        case "vi"
-            //Vietnamese Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/2/21/Flag_of_Vietnam.svg/2000px-Flag_of_Vietnam.svg.png";
-      break;
-        case "zs"
-            //Chinese Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Flag_of_the_People's_Republic_of_China.svg/2000px-Flag_of_the_People's_Republic_of_China.svg.png";
-      break;
-        case "ko"
-            //Korean Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/2000px-Flag_of_South_Korea.svg.png";
-      break;
-        case "cs"
-            //Czech Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Flag_of_the_Czech_Republic.svg/2000px-Flag_of_the_Czech_Republic.svg.png";
-      break; 
-        case "hi"
-            //Indian Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/en/thumb/4/41/Flag_of_India.svg/1350px-Flag_of_India.svg.png";
-      break;
-        case "th"
-            //Thai Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Flag_of_Thailand.svg/2000px-Flag_of_Thailand.svg.png";
-      break;
-        case "tr"
-            //Turkish Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Flag_of_Turkey.svg/2000px-Flag_of_Turkey.svg.png";
-      break;
-        case "id"
-            //Indonesian Flag
-            backgroundurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Flag_of_Indonesia.svg/2000px-Flag_of_Indonesia.svg.png";
-      break;
-        case "all"
-            //All of the world flags
-            backgroundurl = "http://imagesci.com/img/2013/23/world-flags-11854-hd-wallpapers.png";
-      default:
-      backgroundurl = "http://imagesci.com/img/2013/23/world-flags-11854-hd-wallpapers.png";
+            // American flag
+            backgroundurl = "http://i.imgur.com/3KI66sY.jpg";
+			break;
+        default:
+			backgroundurl = "http://i.imgur.com/3KI66sY.jpg";
             break;
     }
-    $("body").css("background", "url("+backgroundurl+")");
-    $("body").css("background-size", "100%");
-    $("body").css("background-repeat", "no-repeat");
-    $("body").css("background-attachment", "fixed");
-    $(".nav-footer").css("text-shadow", "1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
-    $(".nav-footer a").css("color", "white");
-    //$("#app").css("background", "url('http://i.imgur.com/W6psVNL.png') no-repeat bottom center fixed");
-}
-
-function inject(f) { //Inject the script into the document
-    var script;
-    script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.textContent = f.toString();
-    document.head.appendChild(script);
-}
-console.log('Userscript loaded: Duolingo Flag Background');
-function inject(f) { //Inject the script into the document
-    var script;
-    script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.textContent = f.toString();
-    document.head.appendChild(script);
-}
-inject(doFlag);
-$(document).ready(function() {
- doFlag();
-});
-//Meh...
-window.setInterval(function(){
-       doFlag();
-}, 1000);
+  GM_addStyle(".gr__duolingo_com, body, body:first-child, ._3MLiB, ._3giip, ._3PBCS{background:url("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
+//GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -111,6 +111,7 @@ GM_addStyle("._38VWB{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #0
 //beginner card
 GM_addStyle(".a-Y8L{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
 //footer
-GM_addStyle("._3GXmV, ._1sntG{background:none");
+//GM_addStyle("._3GXmV, ._1sntG{background:none");
+GM_addStyle("._3GXmV{background:none"); //_3uFh7 _3BtZs _1sntG
 //mark all correct answers
 GM_addStyle(".maOx8, ._2hYEZ{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -9,8 +9,16 @@
 // @grant        GM_addStyle
 // ==/UserScript==
 // 
-;var loc = window.location.pathname;
+
+//HACKY HACK USE AS REFERENCE TO FIX ORIGINAL
+
+var uiLanguage = duo.uiLanguage;
+var fromLanguage = userINFO.fromLanguage;
+//var toLanguage = userINFO.toLanguage; y u no exist‽
+//var languagestring = duo.user.get("learning_language");
+//var loc = window.location.pathname;
 var languagestring = window.location.pathname.split("/").slice( 2, 3 ).join("/");
+
 //GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 	var backgroundurl = "notset";
     switch(languagestring){
@@ -115,3 +123,7 @@ GM_addStyle(".a-Y8L{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #00
 GM_addStyle("._3GXmV{background:none"); //_3uFh7 _3BtZs _1sntG
 //mark all correct answers
 GM_addStyle(".maOx8, ._2hYEZ{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
+
+//nvm on this one, short flags don't fill to bottom
+//home page underfooter with wide window: <div data-reactroot="">
+GM_addStyle("body div div("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -110,6 +110,10 @@ var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learning
             // Chinese flag
             backgroundurl = "https://img13.deviantart.net/0a53/i/2009/026/e/2/people__s_republic_of_china_gf_by_think0.jpg";
 			break;
+        case "ko":
+            // Korean flag
+            backgroundurl = "https://pre00.deviantart.net/d168/th/pre/i/2009/041/d/b/south_korea_grunge_flag_by_think0.jpg";
+			break;
         case "en":
             // American flag
             backgroundurl = "http://i.imgur.com/3KI66sY.jpg";

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -9,8 +9,6 @@
 // @grant        GM_addStyle
 // ==/UserScript==
 // 
-
-//HACKY HACK USE AS REFERENCE TO FIX ORIGINAL
 ;var loc = window.location.pathname;
 var languagestring = window.location.pathname.split("/").slice( 2, 3 ).join("/");
 //GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
@@ -102,3 +100,17 @@ var languagestring = window.location.pathname.split("/").slice( 2, 3 ).join("/")
     }
   GM_addStyle(".gr__duolingo_com, body, body:first-child, ._3MLiB, ._3giip, ._3PBCS{background:url("+backgroundurl+");background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 //GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
+//
+GM_addStyle(".nav-footer{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
+GM_addStyle(".nav-footer a{color:white");
+    //$("#app").css("background", "url('http://i.imgur.com/W6psVNL.png') no-repeat bottom center fixed");
+    //
+//write this in english
+GM_addStyle("._1Zqmf{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
+GM_addStyle("._38VWB{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
+//beginner card
+GM_addStyle(".a-Y8L{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");
+//footer
+GM_addStyle("._3GXmV, ._1sntG{background:none");
+//mark all correct answers
+GM_addStyle(".maOx8, ._2hYEZ{text-shadow:1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000");

--- a/Userscript- Flag Background.js
+++ b/Userscript- Flag Background.js
@@ -18,9 +18,8 @@ var fromLanguage = userINFO.fromLanguage;
 //var toLanguage = userINFO.toLanguage; y u no exist‽
 //var languagestring = duo.user.get("learning_language");
 //var loc = window.location.pathname;
-var languagestring = window.location.pathname.split("/").slice( 2, 3 ).join("/");
 */
-var languagestring = JSON.parse(localStorage.getItem("duo.state")).user.learningLanguage;
+var languagestring = JSON.parse(localStorage.getItem('duo.state')).user.learningLanguage || JSON.parse(GM.getValue('duo.state')).user.learningLanguage || window.location.pathname.split("/").slice( 2, 3 ).join("/");
 
 //GM_addStyle("._3giip, ._3PBCS{background:url(http://i.imgur.com/RqTOULB.jpg);background-size:100%;background-repeat:no-repeat;background-attachment:fixed}")
 	var backgroundurl = "notset";


### PR DESCRIPTION
Greasemonkey currently doesn't even load new scripts, so I'm using Violentmonkey.
The script as you have it no longer changes duolingo's background. I hacked at it until I got the background mostly working again, by getting the language code from ~~the url (which is the wrong way to do it)~~ *from localStorage*, processing that immediately, and just injecting the css as-is. *still need to update the flag when the language changes*
You, as the original creator of the userscript, should be able to find the right way to update this for current duolingo page layout/class names.

Background:
.gr__duolingo_com is the strip below the header on the home page.
body, body:first-child, and/or LFfrA _3MLiB is the rest of the home page.
._3giip, ._3PBCS is the skill page, where the element changes based on window size.
._3GXmV footer before it turns red/green for an answer (with ._1sntG to make the answer color narrower)

Text shadow:
._1Zqmf and ._38VWB The Write this in english prompt and text
.a-Y8L the picture cards in the very first lesson
.maOx8, ._2hYEZ mark all correct answers